### PR TITLE
Set default djgpp TARGET to i386-pc-msdosdjgpp.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,13 +16,13 @@ jobs:
         build-type: [ clean ]
         env:
           -
-            TARGET: i586-pc-msdosdjgpp
+            TARGET: i386-pc-msdosdjgpp
             PACKAGES: binutils gcc djgpp-2.05
           -
-            TARGET: i586-pc-msdosdjgpp
+            TARGET: i386-pc-msdosdjgpp
             PACKAGES: binutils gcc djgpp-cvs
           -
-            TARGET: i586-pc-msdosdjgpp
+            TARGET: i386-pc-msdosdjgpp
             PACKAGES: gdb
           -
             TARGET: arm-eabi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ### Upgrade notes:
 
+* 2020-02-13: default target for djgpp has changed to `i386-pc-msdosdjgpp`.  
+If you require compatibility with distributions that use `i586`, you can either:
+    - run `sudo i386-pc-msdosdjgpp-link-i586` after installing, or
+    - build with `./build-djgpp.sh --prefix=i586-pc-msdosdjgpp`.
 * 2020-02-07: setenv script is now installed to `$PREFIX/bin/$TARGET-setenv`.
 * 2019-06-06: `master` is now the default branch again.
 
@@ -19,7 +23,7 @@
 
 ### Tested targets:
 
-* i586-pc-msdosdjgpp
+* i386-pc-msdosdjgpp
 * ia16
 * arm-eabi
 * avr
@@ -106,7 +110,7 @@ MAKE_CHECK_GCC=             # Run gcc test suites.
 
 Pick the script you want to use:
 ```sh
-build-djgpp.sh      # builds a toolchain targeting djgpp (default TARGET: i586-pc-msdosdjgpp)
+build-djgpp.sh      # builds a toolchain targeting djgpp (default TARGET: i386-pc-msdosdjgpp)
 build-newlib.sh     # builds a toolchain with the newlib C library
 build-ia16.sh       # builds a toolchain targeting 8086 processors, with the newlib C library (fixed TARGET: ia16-elf)
 build-avr.sh        # builds a toolchain targeting AVR microcontrollers (fixed TARGET: avr)

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -6,7 +6,7 @@ source script/init.sh
 
 case $TARGET in
 *-msdosdjgpp) ;;
-*) TARGET="i586-pc-msdosdjgpp" ;;
+*) TARGET="i386-pc-msdosdjgpp" ;;
 esac
 
 prepend BINUTILS_CONFIGURE_OPTIONS "--disable-werror

--- a/script/finalize.sh
+++ b/script/finalize.sh
@@ -47,9 +47,9 @@ case $TARGET in
 i586-pc-msdosdjgpp) ;;
 *-pc-msdosdjgpp) cat << STOP > ${BASE}/build/${TARGET}-link-i586
 #!/usr/bin/env bash
-echo "Linking ${TARGET}-* to i586-pc-msdosdjgpp-*"
+echo "Linking i586-pc-msdosdjgpp-* to ${TARGET}-*"
 for PROG in ${PREFIX}/bin/${TARGET}-*; do
-  ln -fs `basename \$PROG` \${PROG/$TARGET/i586-pc-msdosdjgpp}
+  ln -fs \`basename \$PROG\` \${PROG/$TARGET/i586-pc-msdosdjgpp}
 done
 STOP
   echo "Installing ${TARGET}-link-i586"

--- a/script/finalize.sh
+++ b/script/finalize.sh
@@ -43,6 +43,22 @@ case $TARGET in
   ;;
 esac
 
+case $TARGET in
+i586-pc-msdosdjgpp) ;;
+*-pc-msdosdjgpp) cat << STOP > ${BASE}/build/${TARGET}-link-i586
+#!/usr/bin/env bash
+echo "Linking ${TARGET}-* to i586-pc-msdosdjgpp-*"
+for PROG in ${PREFIX}/bin/${TARGET}-*; do
+  ln -fs `basename \$PROG` \${PROG/$TARGET/i586-pc-msdosdjgpp}
+done
+STOP
+  echo "Installing ${TARGET}-link-i586"
+  chmod +x ${BASE}/build/${TARGET}-link-i586
+  ${SUDO} cp -p ${BASE}/build/${TARGET}-link-i586 ${DST}/bin/
+  ;;
+*) ;;
+esac
+
 echo "Installing ${TARGET}-setenv"
 chmod +x ${BASE}/build/${TARGET}-setenv
 ${SUDO} cp -p ${BASE}/build/${TARGET}-setenv ${DST}/bin/


### PR DESCRIPTION
This patch changes the default `TARGET` for the djgpp toolchain from `i586-pc-msdosdjgpp` to `i686-pc-msdosdjgpp`, for consistency with other 32-bit x86 toolchains. If you use this script, let me know if you think this is a good idea or not.

If no one responds, I will merge this when the next version of gcc is released.