### PR TITLE
build-djgpp.sh: fix some permission problems

### DIFF
--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -142,7 +142,7 @@ if [ ! -z ${DJGPP_VERSION} ] || [ ! -z ${BUILD_DXEGEN} ]; then
   ${SUDO} cp -p src/stub/${TARGET}-stubify $PREFIX/bin/ || exit 1
   ${SUDO} cp -p src/stub/${TARGET}-stubedit $PREFIX/bin/ || exit 1
 
-  ${SUDO} rm ${PREFIX}/${TARGET}/etc/djgpp-*-installed
+  ${SUDO} rm -f ${PREFIX}/${TARGET}/etc/djgpp-*-installed
   ${SUDO} touch ${PREFIX}/${TARGET}/etc/djgpp-${DJGPP_VERSION}-installed
 fi
 
@@ -246,8 +246,8 @@ if [ ! -z ${GCC_VERSION} ]; then
   ${SUDO} ${MAKE} -j${MAKE_JOBS} install-strip || exit 1
   ${SUDO} ${MAKE} -j${MAKE_JOBS} -C mpfr install
 
-  rm ${PREFIX}/${TARGET}/etc/gcc-*-installed
-  touch ${PREFIX}/${TARGET}/etc/gcc-${GCC_VERSION}-installed
+  ${SUDO} rm -f ${PREFIX}/${TARGET}/etc/gcc-*-installed
+  ${SUDO} touch ${PREFIX}/${TARGET}/etc/gcc-${GCC_VERSION}-installed
 
   export CFLAGS="$TEMP_CFLAGS"
 fi

--- a/script/build-binutils.sh
+++ b/script/build-binutils.sh
@@ -21,5 +21,5 @@ ${MAKE} -j${MAKE_JOBS} || exit 1
 [ ! -z $MAKE_CHECK ] && ${MAKE} -j${MAKE_JOBS} -s check | tee ${BASE}/tests/binutils.log
 ${SUDO} ${MAKE} -j${MAKE_JOBS} install || exit 1
 
-${SUDO} rm ${PREFIX}/${TARGET}/etc/binutils-*-installed
+${SUDO} rm -f ${PREFIX}/${TARGET}/etc/binutils-*-installed
 ${SUDO} touch ${PREFIX}/${TARGET}/etc/binutils-${BINUTILS_VERSION}-installed

--- a/script/build-gdb.sh
+++ b/script/build-gdb.sh
@@ -27,6 +27,6 @@ if [ ! -z ${GDB_VERSION} ]; then
   [ ! -z $MAKE_CHECK ] && ${MAKE} -j${MAKE_JOBS} -s check | tee ${BASE}/tests/gdb.log
   ${SUDO} ${MAKE} -j${MAKE_JOBS} install || exit 1
 
-  ${SUDO} rm ${PREFIX}/${TARGET}/etc/gdb-*-installed
+  ${SUDO} rm -f ${PREFIX}/${TARGET}/etc/gdb-*-installed
   ${SUDO} touch ${PREFIX}/${TARGET}/etc/gdb-${GDB_VERSION}-installed
 fi

--- a/script/build-newlib-gcc.sh
+++ b/script/build-newlib-gcc.sh
@@ -85,6 +85,6 @@ if [ ! -z ${GCC_VERSION} ]; then
   ${SUDO} ${MAKE} -j${MAKE_JOBS} install-strip || exit 1
   ${SUDO} ${MAKE} -j${MAKE_JOBS} -C mpfr install
   
-  ${SUDO} rm ${PREFIX}/${TARGET}/etc/gcc-*-installed
+  ${SUDO} rm -f ${PREFIX}/${TARGET}/etc/gcc-*-installed
   ${SUDO} touch ${PREFIX}/${TARGET}/etc/gcc-${GCC_VERSION}-installed
 fi


### PR DESCRIPTION
This fixes the following:

rm: cannot remove '/usr/local/cross/i586-pc-msdosdjgpp/etc/gcc-8.2.0-installed': Permission denied
touch: cannot touch '/usr/local/cross/i586-pc-msdosdjgpp/etc/gcc-8.2.0-installed': Permission denied