### PR TITLE
Build djgpp libc from source, including latest version from CVS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ compiler:
 
 env:
   - TARGET=i586-pc-msdosdjgpp PACKAGES="binutils gcc djgpp-2.05"
+  - TARGET=i586-pc-msdosdjgpp PACKAGES="binutils gcc djgpp-cvs"
   - TARGET=i586-pc-msdosdjgpp PACKAGES="gdb"
   - TARGET=arm-eabi           PACKAGES="binutils gcc newlib"
   - TARGET=arm-eabi           PACKAGES="gdb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,59 @@
+os:
+  - linux
+  - osx
+
+dist: xenial
+
+language: c++
+
+addons:
+  apt:
+    packages:
+      - bison
+      - flex
+      - curl
+      - make
+      - texinfo
+      - zlib1g-dev
+      - tar
+      - bzip2
+      - gzip
+      - xz-utils
+      - unzip
+      - dos2unix
+      - libtool-bin
+  homebrew:
+    update: true
+    packages:
+      - bison
+      - flex
+      - curl
+      - make
+      - texinfo
+      - zlib
+      - bzip2
+      - gzip
+      - xz
+      - unzip
+      - dos2unix
+      - libtool
+
+compiler:
+  - gcc
+  - clang
+
+env:
+  - TARGET=i586-pc-msdosdjgpp PACKAGES="binutils gcc djgpp-2.05"
+  - TARGET=i586-pc-msdosdjgpp PACKAGES="gdb"
+  - TARGET=arm-eabi           PACKAGES="binutils gcc newlib"
+  - TARGET=arm-eabi           PACKAGES="gdb"
+  - TARGET=avr                PACKAGES="binutils gcc avr-libc"
+  - TARGET=avr                PACKAGES="gdb avarice simulavr avrdude"
+  - TARGET=ia16               PACKAGES="binutils gcc newlib"
+
+before_install:
+#  - if [ $TRAVIS_OS_NAME = 'linux' ] && [ $CC = 'clang' ] ; then sudo apt-get -y install ; fi
+#  - if [ $TRAVIS_OS_NAME = 'osx' ] && [ $CC = 'clang' ]; then brew install ; fi
+
+script:
+  - ./script/test.sh

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 * arm-eabi
 * avr
 
+See the [build logs](https://travis-ci.org/jwt27/build-gcc) on Travis-CI for a detailed status of individual targets.
+
 ### Requirements
 
 Before running this script, you need to install these programs first:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pacman -Syuu base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-curl mingw-w
 Several environment variables control the build process. Usually you only need to specify `TARGET`. Here is the full list:
 ```
 # Primary build options:
-TARGET=                     # Target duplet or triplet.
+TARGET=                     # Target name.
 PREFIX=                     # Install location.
 ENABLE_LANGUAGES=           # Comma-separated list of languages to build compilers for.
 
@@ -88,6 +88,8 @@ GCC_CONFIGURE_OPTIONS=      # Extra options to pass to gcc's ./configure
 BINUTILS_CONFIGURE_OPTIONS= # Same, for binutils
 GDB_CONFIGURE_OPTIONS=      # Same, for gdb
 NEWLIB_CONFIGURE_OPTIONS=   # Same, for newlib
+AVRLIBC_CONFIGURE_OPTIONS=  # Same, for avr-libc
+DJGPP_CFLAGS=               # CFLAGS for building djgpp's libc.
 
 # Misc.
 HOST=                       # The platform you are building for, when building a cross-cross compiler

--- a/build-avr.sh
+++ b/build-avr.sh
@@ -98,6 +98,8 @@ fi
 
 source ${BASE}/script/build-avr-gcc.sh
 
+cd ${BASE}/build/
+
 if [ ! -z ${SIMULAVR_VERSION} ]; then
   echo "Building simulavr"
   cd simulavr/ || exit 1

--- a/build-avr.sh
+++ b/build-avr.sh
@@ -119,6 +119,7 @@ if [ ! -z ${AVARICE_VERSION} ]; then
   echo "Building AVaRICE"
   untar ${AVARICE_ARCHIVE}
   cd avarice-${AVARICE_VERSION}
+  [ -e ${BASE}/patch/patch-avarice-${AVARICE_VERSION}.txt ] && patch -p1 -u < ${BASE}/patch/patch-avarice-${AVARICE_VERSION}.txt || exit 1
   mkdir -p build-avr/
   cd build-avr/ || exit 1
   rm -rf *

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -135,7 +135,7 @@ if [ ! -z ${DJGPP_VERSION} ]; then
 
   cd src
   unset COMSPEC
-  sed -i '50cCROSS_PREFIX = ${TARGET}-' makefile.def
+  sed -i "50cCROSS_PREFIX = ${TARGET}-" makefile.def
   sed -i '61cGCC = \$(CC) -g -O2 \$(HOST_CFLAGS)' makefile.def
   ${MAKE} misc.exe makemake.exe ../hostbin || exit 1
   ${MAKE} config || exit 1

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -21,6 +21,8 @@ prepend GCC_CONFIGURE_OPTIONS "--disable-nls
 prepend GDB_CONFIGURE_OPTIONS "--disable-werror
                                --disable-nls"
 
+prepend DJGPP_CFLAGS "-O2"
+
 if [ -z $1 ]; then
   echo "Usage: $0 [packages...]"
   echo "Supported packages:"
@@ -269,7 +271,7 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   echo "Building djgpp libc"
   cd ${BASE}/build/djgpp-${DJGPP_VERSION}/src
   TEMP_CFLAGS="$CFLAGS"
-  CFLAGS="$DJGPP_CFLAGS"
+  export CFLAGS="$DJGPP_CFLAGS"
   ${MAKE} -j${MAKE_JOBS}|| exit 1
   CFLAGS="$TEMP_CFLAGS"
   cd ..

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -275,36 +275,7 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   echo "Installing djgpp libc"
   ${SUDO} mkdir -p ${PREFIX}/${TARGET}/lib
   ${SUDO} cp -rp ../lib/* $PREFIX/${TARGET}/lib || exit 1
-
-  #${MAKE} -j${MAKE_JOBS} -C debug || exit 1
-  ${MAKE} -j${MAKE_JOBS} -C libemu || exit 1
-  ${MAKE} -j${MAKE_JOBS} -C libm || exit 1
-  ${MAKE} -j${MAKE_JOBS} -C utils native || exit 1
-  ${MAKE} -j${MAKE_JOBS} -C docs || exit 1
-  #${MAKE} -j${MAKE_JOBS} -C ../zoneinfo/src
-  ${MAKE} -j${MAKE_JOBS} -f makempty || exit 1
   CFLAGS="$TEMP_CFLAGS"
-  cd ..
-
-  echo "Installing djgpp libraries and utilities"
-  ${SUDO} cp -rp lib/* $PREFIX/${TARGET}/lib || exit 1
-  ${SUDO} cp -p hostbin/exe2coff.exe $PREFIX/bin/${TARGET}-exe2coff${EXE} || exit 1
-  ${SUDO} cp -p hostbin/djasm.exe $PREFIX/bin/${TARGET}-djasm${EXE} || exit 1
-  ${SUDO} mkdir -p ${PREFIX}/${TARGET}/share/info
-  ${SUDO} cp -rp info/* ${PREFIX}/${TARGET}/share/info
-
-  if [ ! -z ${BUILD_DXEGEN} ]; then
-    echo "Building DXE tools"
-    ${MAKE} -j${MAKE_JOBS} -C dxe native || exit 1
-    echo "Installing DXE tools"
-    ${SUDO} cp -p hostbin/dxegen.exe  $PREFIX/bin/${TARGET}-dxegen${EXE} || exit 1
-    ${SUDO} ln -s $PREFIX/bin/${TARGET}-dxegen${EXE} $PREFIX/bin/${TARGET}-dxe3gen${EXE} || exit 1
-    ${SUDO} cp -p hostbin/dxe3res.exe $PREFIX/bin/${TARGET}-dxe3res${EXE} || exit 1
-    touch ${PREFIX}/${TARGET}/etc/dxegen-installed
-  fi
-
-  ${SUDO} rm -f ${PREFIX}/${TARGET}/etc/djgpp-*-installed
-  ${SUDO} touch ${PREFIX}/${TARGET}/etc/djgpp-${DJGPP_VERSION}-installed
 fi
 
 if [ ! -z ${GCC_VERSION} ]; then
@@ -323,6 +294,41 @@ if [ ! -z ${GCC_VERSION} ]; then
 
   ${SUDO} rm -f ${PREFIX}/${TARGET}/etc/gcc-*-installed
   ${SUDO} touch ${PREFIX}/${TARGET}/etc/gcc-${GCC_VERSION}-installed
+fi
+
+if [ ! -z ${DJGPP_VERSION} ]; then
+  echo "Building djgpp libraries"
+  cd ${BASE}/build/djgpp-${DJGPP_VERSION}/src
+  TEMP_CFLAGS="$CFLAGS"
+  export CFLAGS="$DJGPP_CFLAGS"
+  ${MAKE} -j${MAKE_JOBS} -C dxe native || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C debug || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C libemu || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C libm || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C utils native || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C docs || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C ../zoneinfo/src
+  ${MAKE} -j${MAKE_JOBS} -f makempty || exit 1
+  CFLAGS="$TEMP_CFLAGS"
+  cd ..
+
+  echo "Installing djgpp libraries and utilities"
+  ${SUDO} cp -rp lib/* $PREFIX/${TARGET}/lib || exit 1
+  ${SUDO} cp -p hostbin/exe2coff.exe $PREFIX/bin/${TARGET}-exe2coff${EXE} || exit 1
+  ${SUDO} cp -p hostbin/djasm.exe $PREFIX/bin/${TARGET}-djasm${EXE} || exit 1
+  ${SUDO} mkdir -p ${PREFIX}/${TARGET}/share/info
+  ${SUDO} cp -rp info/* ${PREFIX}/${TARGET}/share/info
+
+  if [ ! -z ${BUILD_DXEGEN} ]; then
+    echo "Installing DXE tools"
+    ${SUDO} cp -p hostbin/dxegen.exe  $PREFIX/bin/${TARGET}-dxegen${EXE} || exit 1
+    ${SUDO} ln -s $PREFIX/bin/${TARGET}-dxegen${EXE} $PREFIX/bin/${TARGET}-dxe3gen${EXE} || exit 1
+    ${SUDO} cp -p hostbin/dxe3res.exe $PREFIX/bin/${TARGET}-dxe3res${EXE} || exit 1
+    touch ${PREFIX}/${TARGET}/etc/dxegen-installed
+  fi
+
+  ${SUDO} rm -f ${PREFIX}/${TARGET}/etc/djgpp-*-installed
+  ${SUDO} touch ${PREFIX}/${TARGET}/etc/djgpp-${DJGPP_VERSION}-installed
 fi
 
 cd ${BASE}/build

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -97,7 +97,7 @@ if [ ! -z ${BINUTILS_VERSION} ]; then
   cd bnu${BINUTILS_VERSION}s
   if [ ! -e binutils-unpacked ]; then
     echo "Unpacking binutils..."
-    unzip -o ../../download/bnu${BINUTILS_VERSION}s.zip || exit 1
+    unzip -oq ../../download/bnu${BINUTILS_VERSION}s.zip || exit 1
 
     # patch for binutils 2.27
     [ ${BINUTILS_VERSION} == 227 ] && (patch gnu/binutils-*/bfd/init.c ${BASE}/patch/patch-bnu27-bfd-init.txt || exit 1 )
@@ -126,9 +126,9 @@ if [ ! -z ${DJGPP_VERSION} ]; then
     rm -rf djgpp-${DJGPP_VERSION}/
     mkdir -p djgpp-${DJGPP_VERSION}/
     cd djgpp-${DJGPP_VERSION}/ || exit 1
-    unzip -uo ../../download/djdev${DJGPP_VERSION}.zip || exit 1
-    unzip -uo ../../download/djlsr${DJGPP_VERSION}.zip || exit 1
-    unzip -uo ../../download/djcrx${DJGPP_VERSION}.zip || exit 1
+    unzip -uoq ../../download/djdev${DJGPP_VERSION}.zip || exit 1
+    unzip -uoq ../../download/djlsr${DJGPP_VERSION}.zip || exit 1
+    unzip -uoq ../../download/djcrx${DJGPP_VERSION}.zip || exit 1
     patch -p1 -u < ../../patch/patch-djlsr${DJGPP_VERSION}.txt || exit 1
     patch -p1 -u < ../../patch/patch-djcrx${DJGPP_VERSION}.txt || exit 1
   fi

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -267,8 +267,8 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   cd ${BASE}/build/djgpp-${DJGPP_VERSION}/src
   TEMP_CFLAGS="$CFLAGS"
   export CFLAGS="$DJGPP_CFLAGS"
+  sed -i 's/Werror/Wno-error/' makefile.cfg
   ${MAKE} config || exit 1
-  echo "-Wno-error" >> gcc.opt
   ${MAKE} -j${MAKE_JOBS} -C mkdoc || exit 1
   ${MAKE} -j${MAKE_JOBS} -C libc || exit 1
 

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -269,7 +269,15 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   cd ${BASE}/build/djgpp-${DJGPP_VERSION}/src
   TEMP_CFLAGS="$CFLAGS"
   export CFLAGS="$DJGPP_CFLAGS"
-  ${MAKE} -j${MAKE_JOBS}|| exit 1
+  ${MAKE} -j${MAKE_JOBS} -C mkdoc || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C libc || exit 1
+  #${MAKE} -j${MAKE_JOBS} -C debug || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C libemu || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C libm || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C utils native || exit 1
+  ${MAKE} -j${MAKE_JOBS} -C docs || exit 1
+  #${MAKE} -j${MAKE_JOBS} -C ../zoneinfo/src
+  ${MAKE} -j${MAKE_JOBS} -f makempty || exit 1
   CFLAGS="$TEMP_CFLAGS"
   cd ..
 
@@ -281,6 +289,8 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   ${SUDO} cp -rp info/* ${PREFIX}/${TARGET}/share/info
 
   if [ ! -z ${BUILD_DXEGEN} ]; then
+    echo "Building DXE tools"
+    ${MAKE} -j${MAKE_JOBS} -C dxe native || exit 1
     echo "Installing DXE tools"
     ${SUDO} cp -p hostbin/dxegen.exe  $PREFIX/bin/${TARGET}-dxegen${EXE} || exit 1
     ${SUDO} ln -s $PREFIX/bin/${TARGET}-dxegen${EXE} $PREFIX/bin/${TARGET}-dxe3gen${EXE} || exit 1

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -289,6 +289,7 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   echo "Installing djgpp libraries and utilities"
   ${SUDO} cp -rp lib/* $PREFIX/${TARGET}/lib || exit 1
   ${SUDO} cp -p hostbin/exe2coff.exe $PREFIX/bin/${TARGET}-exe2coff${EXE} || exit 1
+  ${SUDO} cp -p hostbin/djasm.exe $PREFIX/bin/${TARGET}-djasm${EXE} || exit 1
   ${SUDO} mkdir -p ${PREFIX}/${TARGET}/share/info
   ${SUDO} cp -rp info/* ${PREFIX}/${TARGET}/share/info
 

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -271,6 +271,11 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   echo "-Wno-error" >> gcc.opt
   ${MAKE} -j${MAKE_JOBS} -C mkdoc || exit 1
   ${MAKE} -j${MAKE_JOBS} -C libc || exit 1
+
+  echo "Installing djgpp libc"
+  ${SUDO} mkdir -p ${PREFIX}/${TARGET}/lib
+  ${SUDO} cp -rp ../lib/* $PREFIX/${TARGET}/lib || exit 1
+
   #${MAKE} -j${MAKE_JOBS} -C debug || exit 1
   ${MAKE} -j${MAKE_JOBS} -C libemu || exit 1
   ${MAKE} -j${MAKE_JOBS} -C libm || exit 1
@@ -281,8 +286,7 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   CFLAGS="$TEMP_CFLAGS"
   cd ..
 
-  echo "Installing djgpp libc"
-  ${SUDO} mkdir -p ${PREFIX}/${TARGET}/lib
+  echo "Installing djgpp libraries and utilities"
   ${SUDO} cp -rp lib/* $PREFIX/${TARGET}/lib || exit 1
   ${SUDO} cp -p hostbin/exe2coff.exe $PREFIX/bin/${TARGET}-exe2coff${EXE} || exit 1
   ${SUDO} mkdir -p ${PREFIX}/${TARGET}/share/info

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -45,7 +45,7 @@ if [ -z ${IGNORE_DEPENDENCIES} ]; then
   [ ! -z ${GCC_VERSION} ] && DEPS+=" djgpp binutils"
   [ ! -z ${BINUTILS_VERSION} ] && DEPS+=" "
   [ ! -z ${GDB_VERSION} ] && DEPS+=" "
-  [ ! -z ${DJGPP_VERSION} ] && DEPS+=" "
+  [ ! -z ${DJGPP_VERSION} ] && DEPS+=" binutils gcc"
   [ ! -z ${BUILD_DXEGEN} ] && DEPS+=" djgpp binutils gcc"
   
   for DEP in ${DEPS}; do

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -134,6 +134,7 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   cd src
   unset COMSPEC
   sed -i '50cCROSS_PREFIX = ${TARGET}-' makefile.def
+  sed -i '61cGCC = \$(CC) -g -O2 \$(HOST_CFLAGS)' makefile.def
   ${MAKE} misc.exe makemake.exe ../hostbin || exit 1
   ${MAKE} config || exit 1
   echo "-Wno-error" >> gcc.opt
@@ -267,7 +268,10 @@ fi
 if [ ! -z ${DJGPP_VERSION} ]; then
   echo "Building djgpp libc"
   cd ${BASE}/build/djgpp-${DJGPP_VERSION}/src
+  TEMP_CFLAGS="$CFLAGS"
+  CFLAGS="$DJGPP_CFLAGS"
   ${MAKE} -j${MAKE_JOBS}|| exit 1
+  CFLAGS="$TEMP_CFLAGS"
   cd ..
 
   echo "Installing djgpp libc"

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -138,8 +138,6 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   sed -i "50cCROSS_PREFIX = ${TARGET}-" makefile.def
   sed -i '61cGCC = \$(CC) -g -O2 \$(HOST_CFLAGS)' makefile.def
   ${MAKE} misc.exe makemake.exe ../hostbin || exit 1
-  ${MAKE} config || exit 1
-  echo "-Wno-error" >> gcc.opt
   ${MAKE} -C djasm native || exit 1
   ${MAKE} -C stub native || exit 1
   cd ..
@@ -269,6 +267,8 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   cd ${BASE}/build/djgpp-${DJGPP_VERSION}/src
   TEMP_CFLAGS="$CFLAGS"
   export CFLAGS="$DJGPP_CFLAGS"
+  ${MAKE} config || exit 1
+  echo "-Wno-error" >> gcc.opt
   ${MAKE} -j${MAKE_JOBS} -C mkdoc || exit 1
   ${MAKE} -j${MAKE_JOBS} -C libc || exit 1
   #${MAKE} -j${MAKE_JOBS} -C debug || exit 1

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -301,11 +301,11 @@ if [ ! -z ${DJGPP_VERSION} ]; then
   cd ${BASE}/build/djgpp-${DJGPP_VERSION}/src
   TEMP_CFLAGS="$CFLAGS"
   export CFLAGS="$DJGPP_CFLAGS"
+  ${MAKE} -j${MAKE_JOBS} -C utils native || exit 1
   ${MAKE} -j${MAKE_JOBS} -C dxe native || exit 1
   ${MAKE} -j${MAKE_JOBS} -C debug || exit 1
   ${MAKE} -j${MAKE_JOBS} -C libemu || exit 1
   ${MAKE} -j${MAKE_JOBS} -C libm || exit 1
-  ${MAKE} -j${MAKE_JOBS} -C utils native || exit 1
   ${MAKE} -j${MAKE_JOBS} -C docs || exit 1
   ${MAKE} -j${MAKE_JOBS} -C ../zoneinfo/src
   ${MAKE} -j${MAKE_JOBS} -f makempty || exit 1

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -220,6 +220,7 @@ if [ ! -z ${GCC_VERSION} ]; then
     # download mpc/gmp/mpfr/isl libraries
     echo "Downloading gcc dependencies"
     cd gnu/gcc-${GCC_VERSION} || exit 1
+    sed -i 's/ftp/http/' contrib/download_prerequisites
     ./contrib/download_prerequisites || exit 1
 
     # apply extra patches if necessary

--- a/build-ia16.sh
+++ b/build-ia16.sh
@@ -79,9 +79,16 @@ source ${BASE}/script/build-tools.sh
 
 cd ${BASE}/build/ || exit 1
 
-download_git https://github.com/tkchia/gcc-ia16.git gcc-6_3_0-ia16-tkchia
+if [ ! -z ${GCC_VERSION} ]; then
+  download_git https://github.com/tkchia/gcc-ia16.git gcc-6_3_0-ia16-tkchia
+  cd gcc-ia16/
+  patch -p1 -u < ../../patch/patch-gcc-ia16.txt || exit 1
+  cd ..
+fi
 
-download_git https://github.com/tkchia/newlib-ia16.git newlib-2_4_0-ia16-tkchia
+if [ ! -z ${NEWLIB_VERSION} ]; then
+  download_git https://github.com/tkchia/newlib-ia16.git newlib-2_4_0-ia16-tkchia
+fi
 
 if [ ! -z ${BINUTILS_VERSION} ]; then
   if [ "$BINUTILS_VERSION" = "ia16" ]; then

--- a/djgpp/djgpp-cvs
+++ b/djgpp/djgpp-cvs
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+export DJGPP_VERSION=cvs

--- a/patch/patch-avarice-2.13.txt
+++ b/patch/patch-avarice-2.13.txt
@@ -1,0 +1,23 @@
+Description: Fix FTBFS for GCC 5
+Author: Tobias Frost <tobi@debian.org>
+Bug: https://sourceforge.net/p/avarice/patches/34/
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=777789
+Last-Update: 2015-05-18
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/src/pragma.h
++++ b/src/pragma.h
+@@ -28,9 +28,10 @@
+  */
+ #if defined(__GNUC__)
+ #  if __GNUC__ > 4
+-#      define PRAGMA_DIAG_PUSH       _Pragma(GCC diagnostic push)
+-#      define PRAGMA_DIAG_POP        _Pragma(GCC diagnostic pop)
+-#      define PRAGMA_DIAG_IGNORED(x) _Pragma(GCC diagnostic ignored x)
++#      define PRAGMA_DIAG_PUSH       _Pragma("GCC diagnostic push")
++#      define PRAGMA_DIAG_POP        _Pragma("GCC diagnostic pop")
++#      define PRAGMA_(x)             _Pragma(#x)
++#      define PRAGMA_DIAG_IGNORED(x) PRAGMA_(GCC diagnostic ignored x)
+ #  elif __GNUC__ == 4
+ #    if __GNUC_MINOR__ >= 6
+ #      define PRAGMA_DIAG_PUSH       _Pragma("GCC diagnostic push")

--- a/patch/patch-djlsr205.txt
+++ b/patch/patch-djlsr205.txt
@@ -271,26 +271,24 @@ index 1bb6aa55..f0ba9919 100644
  void
  __crt1_startup(void)
  {
-diff --git a/src/makefile.cfg b/src/makefile.cfg
-index 11bb06db..1a709f97 100644
 --- a/src/makefile.cfg
 +++ b/src/makefile.cfg
-@@ -55,6 +55,7 @@ gcc.opt: makefile.cfg
-        @./misc.exe echo - "-Wsign-compare" >>gcc.opt
-        @./misc.exe echo - "-nostdinc" >>gcc.opt
-        @./misc.exe echo - "$(IQUOTE)" >>gcc.opt
-+       @./misc.exe echo - "-mpreferred-stack-boundary=4" >>gcc.opt
-
-
+@@ -48,6 +48,7 @@
+ 	@./misc.exe echo - "-Wsign-compare" >>gcc.opt
+ 	@./misc.exe echo - "-nostdinc" >>gcc.opt
+ 	@./misc.exe echo - "$(IQUOTE)" >>gcc.opt
++	@./misc.exe echo - "-mpreferred-stack-boundary=4" >>gcc.opt
+ 
+ 
  gcc-l.opt: makefile.cfg
-@@ -65,6 +66,7 @@ gcc-l.opt: makefile.cfg
-        @./misc.exe echo - "-Wall" >>gcc-l.opt
-        @./misc.exe echo - "-nostdinc" >>gcc-l.opt
-        @./misc.exe echo - "$(IQUOTE)" >>gcc-l.opt
-+       @./misc.exe echo - "-mpreferred-stack-boundary=4" >>gcc-l.opt
-
+@@ -58,6 +59,7 @@
+ 	@./misc.exe echo - "-Wall" >>gcc-l.opt
+ 	@./misc.exe echo - "-nostdinc" >>gcc-l.opt
+ 	@./misc.exe echo - "$(IQUOTE)" >>gcc-l.opt
++	@./misc.exe echo - "-mpreferred-stack-boundary=4" >>gcc.opt
+ 
  gpp.opt: gcc.opt
-        sed -f gpp.sed $< > $@
+ 	sed -f gpp.sed $< > $@
 --- a/src/libc/ansi/stdlib/nmalloc.c
 +++ b/src/libc/ansi/stdlib/nmalloc.c
 @@ -1145,6 +1145,7 @@

--- a/patch/patch-djlsr205.txt
+++ b/patch/patch-djlsr205.txt
@@ -93,39 +93,7 @@ diff -ur djlsr205-orig/src/dxe/dxe3gen.c djlsr205/src/dxe/dxe3gen.c
    {
      if (VALID_RELOC(relocs[i]))
        fwrite(&relocs[i].r_vaddr, 1, sizeof(relocs[0].r_vaddr), outf);
-diff -ur djlsr205-orig/src/makefile djlsr205/src/makefile
---- djlsr205-orig/src/makefile	2017-04-29 14:32:47.000000000 +0800
-+++ djlsr205/src/makefile	2017-04-29 14:32:57.000000000 +0800
-@@ -40,17 +40,18 @@
- 	$(MAKE) -C stub native
- 	$(MAKE) -C utils native
- 	$(MAKE) -C dxe native
--	$(MAKE) -C mkdoc
--	$(MAKE) -C libc
--	$(MAKE) -C debug
--	$(MAKE) -C djasm
--	$(MAKE) -C stub
--	$(MAKE) -C dxe
--	$(MAKE) -C libemu
--	$(MAKE) -C libm
--	$(MAKE) -C utils
--	$(MAKE) -C docs
--	-$(MAKE) -C ../zoneinfo/src
-+	$(MAKE) -C dxe -f makefile.dxe
-+	#$(MAKE) -C mkdoc
-+	#$(MAKE) -C libc
-+	#$(MAKE) -C debug
-+	#$(MAKE) -C djasm
-+	#$(MAKE) -C stub
-+	#$(MAKE) -C dxe
-+	#$(MAKE) -C libemu
-+	#$(MAKE) -C libm
-+	#$(MAKE) -C utils
-+	#$(MAKE) -C docs
-+	#-$(MAKE) -C ../zoneinfo/src
- 	$(MAKE) -f makempty
- 
- .PHONY : clean
+
 diff -ur djlsr205-orig/src/misc.c djlsr205/src/misc.c
 --- djlsr205-orig/src/misc.c	2017-04-29 14:32:47.000000000 +0800
 +++ djlsr205/src/misc.c	2017-04-29 14:32:57.000000000 +0800
@@ -158,3 +126,136 @@ diff -ur djlsr205-orig/src/stub/exe2coff.c djlsr205/src/stub/exe2coff.c
  
  static void
  exe2aout(char *fname)
+
+--- a/src/makefile.def
++++ b/src/makefile.def
+@@ -47,11 +47,12 @@
+
+ # For building distributed (djgpp) libraries and programs
+
+-CROSS_GCC = i586-pc-msdosdjgpp-gcc -pipe
+-CROSS_AR = i586-pc-msdosdjgpp-ar
+-CROSS_AS = i586-pc-msdosdjgpp-as
+-CROSS_LD = i586-pc-msdosdjgpp-ld
+-CROSS_STRIP = i586-pc-msdosdjgpp-strip
++CROSS_PREFIX = i586-pc-msdosdjgpp-
++CROSS_GCC = $(CROSS_PREFIX)gcc -pipe
++CROSS_AR = $(CROSS_PREFIX)ar
++CROSS_AS = $(CROSS_PREFIX)as
++CROSS_LD = $(CROSS_PREFIX)ld
++CROSS_STRIP = $(CROSS_PREFIX)strip
+ CROSS_BISON = bison
+
+ # For building programs that *run* during the build (hostbin/*);
+diff --git a/src/debug/common/dbgcom.c b/src/debug/common/dbgcom.c
+index 77ca122b..1480f27c 100644
+--- a/src/debug/common/dbgcom.c
++++ b/src/debug/common/dbgcom.c
+@@ -1338,13 +1338,13 @@ int invalid_sel_addr(short sel, unsigned a, unsigned len, char for_write)
+     ("										\n\
+       movw  %2,%%ax								\n\
+       verr  %%ax								\n\
+-      jnz   .Ldoes_not_has_read_right						\n\
++      jnz   .Ldoes_not_has_read_right%=					\n\
+       movb  $1,%0								\n\
+-.Ldoes_not_has_read_right:							\n\
++.Ldoes_not_has_read_right%=:							\n\
+       verw  %%ax								\n\
+-      jnz   .Ldoes_not_has_write_right						\n\
++      jnz   .Ldoes_not_has_write_right%=					\n\
+       movb  $1,%1								\n\
+-.Ldoes_not_has_write_right: "
++.Ldoes_not_has_write_right%=: "
+      : "=qm" (read_allowed), "=qm" (write_allowed)
+      : "g" (sel)
+      );
+diff --git a/src/dxe/makefile b/src/dxe/makefile
+index cf715867..b856b9ed 100644
+--- a/src/dxe/makefile
++++ b/src/dxe/makefile
+@@ -13,7 +13,8 @@ all :: native \
+ 	$(BIN)/dxe3res.exe \
+ 	$E
+ 
+-native :: $(HOSTBIN)/dxegen.exe
++native :: $(HOSTBIN)/dxegen.exe \
++	$(HOSTBIN)/dxe3res.exe
+ 	$(NOP)
+ 
+ .o.h:
+@@ -36,5 +37,8 @@ CROSS_CC = $(word 1,$(CROSS_GCC))
+ $(HOSTBIN)/dxegen.exe : dxe3gen.c init1.h init2.h init3.h init4.h init5.h fini1.h fini2.h fini3.h fini4.h fini5.h
+ 	$(GCC) -DDXE_LD=\"$(CROSS_LD)\" -DDXE_CC=\"$(CROSS_CC)\" -DDXE_AR=\"$(CROSS_AR)\" -DDXE_AS=\"$(CROSS_AS)\" dxe3gen.c -o $@
+ 
++$(HOSTBIN)/dxe3res.exe: dxe3res.c
++	$(GCC) -O2 -Wall dxe3res.c -o $@
++
+ clean ::
+ 	@-$(MISC) rm *.o *.h $(HOSTBIN)/dxegen.exe
+diff --git a/src/makefile b/src/makefile
+index f62b70e4..e6f397fd 100644
+--- a/src/makefile
++++ b/src/makefile
+@@ -21,7 +21,7 @@ DIRS = \
+ 	../info		\
+ 	../lib
+ 
+-all : misc.exe config $(DIRS) makemake.exe subs ../lib/libg.a ../lib/libpc.a
++all : misc.exe config $(DIRS) makemake.exe subs
+ 
+ misc.exe : misc.c
+ 	gcc -O2 -Wall misc.c -o misc.exe
+diff --git a/src/makefile.inc b/src/makefile.inc
+index 664fdf9f..09c6f997 100644
+--- a/src/makefile.inc
++++ b/src/makefile.inc
+@@ -165,7 +165,7 @@ ifneq ($(MAKEFILE_LIB),1)
+ all :: makefile.oh
+ makefile.oh : makefile
+ 	@$(MISC) echo - building new response file
+-	@$(MISC) echo makefile.oh $(addprefix \&/,$(OBJS))
++	@echo "$(addprefix &/,$(OBJS))" > makefile.oh
+ endif
+ 
+ clean ::
+diff --git a/src/makefile.lib b/src/makefile.lib
+index 3a72a464..a3b5bd1e 100644
+--- a/src/makefile.lib
++++ b/src/makefile.lib
+@@ -23,6 +23,7 @@ $(LIB)/lib$(LIBNAME).a : $(OBJS) makefile.rf $(TOP)/../ident.c
+ ifeq ($(CROSS_BUILD),0)
+ 	$(CROSS_AR) q $(LIB)/lib$(LIBNAME).a @makefile.rf id_$(LIBNAME).o
+ else
++	dos2unix makefile.rf
+ 	$(CROSS_AR) q $(LIB)/lib$(LIBNAME).a `cat makefile.rf` id_$(LIBNAME).o
+ endif
+ 	$(CROSS_AR) s $(LIB)/lib$(LIBNAME).a
+diff --git a/src/stub/makefile b/src/stub/makefile
+index 83de0f1d..fef8ac8f 100644
+--- a/src/stub/makefile
++++ b/src/stub/makefile
+@@ -22,6 +22,7 @@ all :: native \
+ native :: \
+ 	$(HOSTBIN)/stubedit.exe \
+ 	$(HOSTBIN)/stubify.exe \
++	$(HOSTBIN)/exe2coff.exe \
+ 	$(INC)/stubinfo.h \
+ 	$E
+ 	$(NOP)
+@@ -63,10 +64,13 @@ $(BIN)/stubedit.exe : $(C) stubedit.o $(L)
+ 
+ 
+ $(HOSTBIN)/stubify.exe : stubify.c stub.h
+-	$(GCC) stubify.c -o $@
++	$(GCC) -O2 stubify.c -o $@
+ 
+ $(HOSTBIN)/stubedit.exe : stubedit.c $(INC)/stubinfo.h
+-	$(GCC) stubedit.c -o $@
++	$(GCC) -O2 stubedit.c -o $@
++
++$(HOSTBIN)/exe2coff.exe : exe2coff.c
++	$(GCC) -O2 $< -o $@
+ 
+ ./stub2inc.exe : stub2inc.c
+ 	$(GCC) stub2inc.c -o $@
+

--- a/patch/patch-djlsr205.txt
+++ b/patch/patch-djlsr205.txt
@@ -291,3 +291,25 @@ index 11bb06db..1a709f97 100644
 
  gpp.opt: gcc.opt
         sed -f gpp.sed $< > $@
+--- a/src/libc/ansi/stdlib/nmalloc.c
++++ b/src/libc/ansi/stdlib/nmalloc.c
+@@ -1145,6 +1145,7 @@
+          return nmalloc(szneed);                      /* EXIT */
+       }
+       else if ((minit = nmalloc(szneed + XTRA))) {
++         m = MEMBLKp(minit);
+          /* alignment >= 2*ALIGN and power of 2 if here */
+          misalign = (ulong)minit % alignment;
+          DBGPRTM("  misalignment = %d", misalign);
+@@ -1154,9 +1155,10 @@
+          }
+          else {
+             /* two or more chunks to release */
+-            /* for now, just return NULL and have a leak */
+             DBGPRTM("  Complex case, release multiple chunks");
+             DBGEOLN;
++            nfree(PTR(split(&m, alignment - misalign)));
++            return nrealloc(PTR(m), size);
+          }
+       } /* alignment > ALIGN */
+    } /* valid parameters */

--- a/patch/patch-djlsr205.txt
+++ b/patch/patch-djlsr205.txt
@@ -258,4 +258,36 @@ index 83de0f1d..fef8ac8f 100644
  
  ./stub2inc.exe : stub2inc.c
  	$(GCC) stub2inc.c -o $@
+diff --git a/src/libc/crt0/crt1.c b/src/libc/crt0/crt1.c
+index 1bb6aa55..f0ba9919 100644
+--- a/src/libc/crt0/crt1.c
++++ b/src/libc/crt0/crt1.c
+@@ -208,7 +208,7 @@ setup_os_version(void)
+   _osminor = v & 0xff;
+ }
 
+-
++__attribute__((force_align_arg_pointer))
+ void
+ __crt1_startup(void)
+ {
+diff --git a/src/makefile.cfg b/src/makefile.cfg
+index 11bb06db..1a709f97 100644
+--- a/src/makefile.cfg
++++ b/src/makefile.cfg
+@@ -55,6 +55,7 @@ gcc.opt: makefile.cfg
+        @./misc.exe echo - "-Wsign-compare" >>gcc.opt
+        @./misc.exe echo - "-nostdinc" >>gcc.opt
+        @./misc.exe echo - "$(IQUOTE)" >>gcc.opt
++       @./misc.exe echo - "-mpreferred-stack-boundary=4" >>gcc.opt
+
+
+ gcc-l.opt: makefile.cfg
+@@ -65,6 +66,7 @@ gcc-l.opt: makefile.cfg
+        @./misc.exe echo - "-Wall" >>gcc-l.opt
+        @./misc.exe echo - "-nostdinc" >>gcc-l.opt
+        @./misc.exe echo - "$(IQUOTE)" >>gcc-l.opt
++       @./misc.exe echo - "-mpreferred-stack-boundary=4" >>gcc-l.opt
+
+ gpp.opt: gcc.opt
+        sed -f gpp.sed $< > $@

--- a/patch/patch-gcc-ia16.txt
+++ b/patch/patch-gcc-ia16.txt
@@ -1,0 +1,15 @@
+diff --git a/gcc/opts.c b/gcc/opts.c
+index 0f9431a0b..91af66f98 100644
+--- a/gcc/opts.c
++++ b/gcc/opts.c
+@@ -2340,8 +2340,8 @@ set_debug_level (enum debug_info_type type, int extended, const char *arg,
+ #endif
+ 	    }
+ 
+-	  if (opts->x_write_symbols == NO_DEBUG)
+-	    warning_at (loc, 0, "target system does not support debug output");
++//	  if (opts->x_write_symbols == NO_DEBUG)
++//	    warning_at (loc, 0, "target system does not support debug output");
+ 	}
+     }
+   else

--- a/script/build-tools.sh
+++ b/script/build-tools.sh
@@ -9,9 +9,12 @@ if [ ! -z $SED_VERSION ]; then
     echo "Building sed"
     untar ${SED_ARCHIVE} || exit 1
     cd sed-${SED_VERSION}/
+    TEMP_CFLAGS="$CFLAGS"
+    export CFLAGS="${CFLAGS//-w}"   # configure fails if warnings are disabled.
     ./configure --prefix=${BASE}/build/tmpinst || exit 1
     ${MAKE} -j${MAKE_JOBS} || exit 1
     ${MAKE} -j${MAKE_JOBS} install || exit 1
+    CFLAGS="$TEMP_CFLAGS"
     touch ${BASE}/build/tmpinst/sed-${SED_VERSION}-installed
   fi
 fi

--- a/script/download.sh
+++ b/script/download.sh
@@ -46,6 +46,9 @@ fi
 if [ ! -z ${AVRLIBC_VERSION} ]; then
   echo "    AVRLIBC_CONFIGURE_OPTIONS=`echo ${AVRLIBC_CONFIGURE_OPTIONS}`"
 fi
+if [ ! -z ${DJGPP_VERSION} ]; then
+  echo "    DJGPP_CFLAGS=`echo ${DJGPP_CFLAGS}`"
+fi
 echo ""
 
 mkdir -p ${PREFIX}
@@ -53,10 +56,10 @@ mkdir -p ${PREFIX}
 if [ ! -d ${PREFIX} ] || [ ! -w ${PREFIX} ]; then
   echo "WARNING: no write access to ${PREFIX}."
   echo "You may need to enter your sudo password several times during the build process."
+  echo ""
   SUDO=sudo
 fi
 
-echo ""
 echo "If you wish to change anything, press CTRL-C now. Otherwise, press any other key to continue."
 read -s -n 1
 

--- a/script/finalize.sh
+++ b/script/finalize.sh
@@ -1,6 +1,7 @@
 echo "Copy long name executables to short name."
 (
   cd $PREFIX || exit 1
+  mkdir -p ${TARGET}/bin
   SHORT_NAME_LIST="gcc g++ c++ addr2line c++filt cpp size strings dxegen dxe3gen dxe3res exe2coff stubify stubedit gdb"
   for SHORT_NAME in $SHORT_NAME_LIST; do
     if [ -f bin/${TARGET}-$SHORT_NAME ]; then

--- a/script/finalize.sh
+++ b/script/finalize.sh
@@ -1,7 +1,7 @@
 echo "Copy long name executables to short name."
 (
   cd $PREFIX || exit 1
-  mkdir -p ${TARGET}/bin
+  ${SUDO} mkdir -p ${TARGET}/bin
   SHORT_NAME_LIST="gcc g++ c++ addr2line c++filt cpp size strings dxegen dxe3gen dxe3res exe2coff stubify stubedit gdb"
   for SHORT_NAME in $SHORT_NAME_LIST; do
     if [ -f bin/${TARGET}-$SHORT_NAME ]; then

--- a/script/finalize.sh
+++ b/script/finalize.sh
@@ -2,7 +2,7 @@ echo "Copy long name executables to short name."
 (
   cd $PREFIX || exit 1
   ${SUDO} mkdir -p ${TARGET}/bin
-  SHORT_NAME_LIST="gcc g++ c++ addr2line c++filt cpp size strings dxegen dxe3gen dxe3res exe2coff stubify stubedit gdb"
+  SHORT_NAME_LIST="gcc g++ c++ addr2line c++filt cpp size strings dxegen dxe3gen dxe3res exe2coff stubify stubedit gdb djasm"
   for SHORT_NAME in $SHORT_NAME_LIST; do
     if [ -f bin/${TARGET}-$SHORT_NAME ]; then
       ${SUDO} cp -p bin/${TARGET}-$SHORT_NAME ${TARGET}/bin/$SHORT_NAME

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+PREFIX="`pwd`/install"
+
+[ $TRAVIS_OS_NAME = 'linux' ] && MAKE_JOBS=`nproc`
+[ $TRAVIS_OS_NAME = 'osx' ] && MAKE_JOBS=`sysctl -n hw.ncpu`
+MAKE_JOBS+=" --quiet"
+
+CFLAGS="-w"
+CXXFLAGS="-w"
+
+export PREFIX MAKE_JOBS CFLAGS CXXFLAGS
+
+case $TARGET in
+*-msdosdjgpp) SCRIPT=./build-djgpp.sh ;;
+ia16*)        SCRIPT=./build-ia16.sh ;;
+avr)          SCRIPT=./build-avr.sh ;;
+*)            SCRIPT=./build-newlib.sh ;;
+esac
+
+echo | ${SCRIPT} ${PACKAGES}


### PR DESCRIPTION
This branch now builds djgpp's libc from source instead of pulling in prebuilt binaries. There is also a new package `djgpp-cvs`, which builds the latest libc from CVS. `djgpp-2.05` is still the default option for now.
I'd like to confirm that this works on all platforms before merging. Especially FreeBSD where clang is the default compiler, I don't know if it's able to build the DXE utilities.